### PR TITLE
Switched default to the public SVN server address

### DIFF
--- a/iai_cad_downloader/scripts/download-cad-models.py
+++ b/iai_cad_downloader/scripts/download-cad-models.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     usage = "usage: %prog [options] [sub-dirs]"
     parser = OptionParser(usage)
     parser.add_option("-s", "--source", dest="source",
-                      default="svn+ssh://svn@svn.ai.uni-bremen.de/cad_models",
+                      default="http://svn.ai.uni-bremen.de/svn/cad_models",
                       help="svn server address to download from")
     parser.add_option("-d", "--dest", dest="destination",
                       default="./meshes",


### PR DESCRIPTION
The iai_cad_downloader retrieved packages from our internal SVN repository by default. If we use it in public ROS packages, we should use the public no-login URL.

If private packages have to be checked out, they can still specify a different source, but I'd propose to switch the default to the public repo.
